### PR TITLE
Migrate to K2 Analysis API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 patchPluginXml {
   sinceBuild = "242.*"
-  untilBuild = "251.*"
+  untilBuild = "252.*"
 }
 
 dependencies {

--- a/src/main/java/siosio/doma/DaoType.kt
+++ b/src/main/java/siosio/doma/DaoType.kt
@@ -1,10 +1,10 @@
 package siosio.doma
 
-import com.intellij.codeInsight.*
-import com.intellij.psi.*
-import org.jetbrains.kotlin.idea.util.findAnnotation
+import com.intellij.codeInsight.AnnotationUtil
+import com.intellij.psi.PsiMethod
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.psi.KtAnnotation
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import siosio.doma.inspection.dao.*
 
@@ -43,9 +43,14 @@ enum class DaoType(
             }
         }
 
-        fun valueOf(function: KtNamedFunction): DaoType? {
-            return values().firstOrNull {
-                function.findAnnotation(FqName(it.annotationName)) != null
+        fun valueOf(function: KtNamedFunction): DaoType? = analyze(function) {
+            val symbol = function.symbol as? KaNamedFunctionSymbol ?: return null
+
+            return values().firstOrNull { daoType ->
+                val annotationFqName = FqName(daoType.annotationName)
+                symbol.annotations.any { anno ->
+                    anno.classId?.asSingleFqName() == annotationFqName
+                }
             }
         }
     }

--- a/src/main/java/siosio/doma/extension/PsiElementExtensions.kt
+++ b/src/main/java/siosio/doma/extension/PsiElementExtensions.kt
@@ -3,62 +3,76 @@ package siosio.doma.extension
 import com.intellij.codeInsight.AnnotationUtil
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.psi.PsiAnnotation
-import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiType
 import com.intellij.psi.util.PsiTypesUtil
-import org.jetbrains.kotlin.nj2k.postProcessing.type
-import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.name.FqName
 
 /**
  * SQLファイルを必要とするかどうか
  *
  * このアノテーションの`sqlFile`属性が`true`の場合は必要
  */
-fun PsiAnnotation.useSqlFile(): Boolean = AnnotationUtil.getBooleanAttributeValue(this, "sqlFile") ?: false
+fun PsiAnnotation.useSqlFile(): Boolean =
+    AnnotationUtil.getBooleanAttributeValue(this, "sqlFile") ?: false
 
-fun PsiElement.isInTest(): Boolean = ProjectFileIndex.SERVICE.getInstance(project).isInTestSourceContent(this.containingFile.virtualFile)
-
-/**
- * このパラメータがEntityかどうか
- */
-fun PsiParameter.isEntity(): Boolean {
-    return this.type.isEntity()
-}
+fun PsiElement.isInTest(): Boolean =
+    ProjectFileIndex.SERVICE.getInstance(project)
+        .isInTestSourceContent(this.containingFile.virtualFile)
 
 /**
- * このパラメータがImmutableEntityかどうか
+ * このパラメータがEntityかどうか (Java)
  */
-fun PsiParameter.isImmutableEntity(): Boolean {
-    return this.type.isImmutableEntity()
-}
+fun PsiParameter.isEntity(): Boolean =
+    this.type.isEntity()
 
 /**
- * このTypeがEntityかどうか
+ * このパラメータがImmutableEntityかどうか (Java)
  */
-fun PsiType.isEntity(): Boolean {
-    return PsiTypesUtil.getPsiClass(this)?.let {
+fun PsiParameter.isImmutableEntity(): Boolean =
+    this.type.isImmutableEntity()
+
+/**
+ * このTypeがEntityかどうか (Java)
+ */
+fun PsiType.isEntity(): Boolean =
+    PsiTypesUtil.getPsiClass(this)?.let {
         AnnotationUtil.isAnnotated(it, "org.seasar.doma.Entity", AnnotationUtil.CHECK_TYPE)
     } == true
-}
 
 /**
- * このTypeがImmutableEntityかどうか
+ * このTypeがImmutableEntityかどうか (Java)
  */
 fun PsiType.isImmutableEntity(): Boolean {
-    val annotation = AnnotationUtil.findAnnotation(PsiTypesUtil.getPsiClass(this), "org.seasar.doma.Entity") ?: return false
+    val annotation = AnnotationUtil.findAnnotation(
+        PsiTypesUtil.getPsiClass(this),
+        "org.seasar.doma.Entity"
+    ) ?: return false
     return AnnotationUtil.getBooleanAttributeValue(annotation, "immutable") == true
 }
 
-fun KtParameter.isEntity(): Boolean {
-    return this.type()?.isEmpty() == true
+/**
+ * この Kotlin パラメータがEntityかどうか (K2 Analysis API)
+ *
+ * Java版 `PsiType.isEntity()` と同様、
+ * 型のクラスに org.seasar.doma.Entity が付いているかを判定する。
+ */
+fun KtParameter.isEntity(): Boolean = analyze(this) {
+    // K2 Analysis API でシンボルと型を取得（getParameterSymbol() → symbol）
+    val paramSymbol = this@isEntity.symbol
+    val paramType = paramSymbol.returnType
+
+    // クラス型に対応するシンボルを取得（expandedClassSymbol → expandedSymbol）
+    val classSymbol = paramType.expandedSymbol as? KaClassSymbol ?: return@analyze false
+
+    val entityFqName = FqName("org.seasar.doma.Entity")
+
+    // クラスに @Entity が付いているか？
+    classSymbol.annotations.any { anno ->
+        anno.classId?.asSingleFqName() == entityFqName
+    }
 }
-
-private fun KotlinType.isEmpty(): Boolean {
-    return true
-}
-
-

--- a/src/main/java/siosio/doma/extension/PsiElementExtensions.kt
+++ b/src/main/java/siosio/doma/extension/PsiElementExtensions.kt
@@ -25,19 +25,19 @@ fun PsiElement.isInTest(): Boolean =
         .isInTestSourceContent(this.containingFile.virtualFile)
 
 /**
- * このパラメータがEntityかどうか (Java)
+ * このパラメータがEntityかどうか
  */
 fun PsiParameter.isEntity(): Boolean =
     this.type.isEntity()
 
 /**
- * このパラメータがImmutableEntityかどうか (Java)
+ * このパラメータがImmutableEntityかどうか
  */
 fun PsiParameter.isImmutableEntity(): Boolean =
     this.type.isImmutableEntity()
 
 /**
- * このTypeがEntityかどうか (Java)
+ * このTypeがEntityかどうか
  */
 fun PsiType.isEntity(): Boolean =
     PsiTypesUtil.getPsiClass(this)?.let {
@@ -45,7 +45,7 @@ fun PsiType.isEntity(): Boolean =
     } == true
 
 /**
- * このTypeがImmutableEntityかどうか (Java)
+ * このTypeがImmutableEntityかどうか
  */
 fun PsiType.isImmutableEntity(): Boolean {
     val annotation = AnnotationUtil.findAnnotation(

--- a/src/main/java/siosio/doma/inspection/dao/KotlinDaoInspector.kt
+++ b/src/main/java/siosio/doma/inspection/dao/KotlinDaoInspector.kt
@@ -4,8 +4,10 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.idea.util.findAnnotation
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import siosio.doma.DomaBundle
 import siosio.doma.inspection.Rule
@@ -21,8 +23,7 @@ fun kotlinRule(rule: KotlinDaoInspectionRule.() -> Unit): KotlinDaoInspectionRul
     return daoInspectionRule
 }
 
-interface KotlinDaoRule : Rule<PsiDaoFunction> {
-}
+interface KotlinDaoRule : Rule<PsiDaoFunction>
 
 /**
  * DAOクラスのインスペクションルール
@@ -56,10 +57,11 @@ class KotlinDaoInspectionRule : Rule<PsiDaoFunction> {
  */
 class KotlinSql(private val required: Boolean) : KotlinDaoRule {
     override fun inspect(problemsHolder: ProblemsHolder, daoFunction: PsiDaoFunction) {
-        if ((!required && !daoFunction.useSqlFile())
-            || daoFunction.getModule() == null
-            || daoFunction.psiFunction.findAnnotation(FqName(sqlAnnotationName)) != null
-            || daoFunction.psiFunction.findAnnotation(FqName(sqlExperimentalAnnotationName)) != null
+        if (
+            (!required && !daoFunction.useSqlFile()) ||
+            daoFunction.getModule() == null ||
+            daoFunction.hasKotlinAnnotation(sqlAnnotationName) ||
+            daoFunction.hasKotlinAnnotation(sqlExperimentalAnnotationName)
         ) {
             return
         }
@@ -79,19 +81,52 @@ class KotlinSql(private val required: Boolean) : KotlinDaoRule {
  */
 class KotlinParameterRule : KotlinDaoRule {
     var message: String? = null
-    private var errorElement: (PsiDaoFunction) -> List<PsiElement> = { psiDaoFunction -> psiDaoFunction.valueParameters }
-    var errorElements: (PsiDaoFunction) -> List<PsiElement> = { psiDaoFunction -> errorElement.invoke(psiDaoFunction) }
+    private var errorElement: (PsiDaoFunction) -> List<PsiElement> =
+        { psiDaoFunction -> psiDaoFunction.valueParameters }
+
+    var errorElements: (PsiDaoFunction) -> List<PsiElement> =
+        { psiDaoFunction -> errorElement.invoke(psiDaoFunction) }
+
     var rule: List<KtParameter>.(PsiDaoFunction) -> Boolean = { _ -> true }
+
     var quickFix: ((PsiElement) -> LocalQuickFix)? = null
+
     override fun inspect(problemsHolder: ProblemsHolder, psiDaoFunction: PsiDaoFunction) {
         val params = psiDaoFunction.valueParameters
         if (!params.rule(psiDaoFunction)) {
-            val register: (PsiElement) -> Unit = when (quickFix) {
-                null -> { el -> problemsHolder.registerProblem(el, DomaBundle.message(message!!)) }
-                else -> { el -> problemsHolder.registerProblem(el, DomaBundle.message(message!!), quickFix!!.invoke(el)) }
-            }
-            errorElements.invoke(psiDaoFunction)
-                .forEach(register)
+            val register: (PsiElement) -> Unit =
+                when (quickFix) {
+                    null -> { el ->
+                        problemsHolder.registerProblem(
+                            el,
+                            DomaBundle.message(message!!)
+                        )
+                    }
+                    else -> { el ->
+                        problemsHolder.registerProblem(
+                            el,
+                            DomaBundle.message(message!!),
+                            quickFix!!.invoke(el)
+                        )
+                    }
+                }
+            errorElements.invoke(psiDaoFunction).forEach(register)
+        }
+    }
+}
+
+/**
+ * PsiDaoFunction に対して、Kotlin 関数として指定アノテーションが付いているかを判定
+ * （K2 Analysis API ベース）
+ */
+private fun PsiDaoFunction.hasKotlinAnnotation(annotationFqName: String): Boolean {
+    val ktFunction = psiFunction as? KtNamedFunction ?: return false
+    val fqName = FqName(annotationFqName)
+
+    return analyze(ktFunction) {
+        val symbol = ktFunction.symbol as? KaNamedFunctionSymbol ?: return@analyze false
+        symbol.annotations.any { anno ->
+            anno.classId?.asSingleFqName() == fqName
         }
     }
 }

--- a/src/main/java/siosio/doma/inspection/dao/SelectMethodRule.kt
+++ b/src/main/java/siosio/doma/inspection/dao/SelectMethodRule.kt
@@ -2,10 +2,10 @@ package siosio.doma.inspection.dao
 
 import com.intellij.codeInsight.intention.*
 import com.intellij.psi.util.*
-import org.jetbrains.kotlin.idea.base.utils.fqname.*
-import org.jetbrains.kotlin.idea.structuralsearch.*
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
+import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.name.*
-import org.jetbrains.kotlin.nj2k.types.*
 import org.jetbrains.kotlin.psi.*
 import siosio.doma.*
 
@@ -55,9 +55,19 @@ val kotlinSelectMethodRule =
     }
 
 private val SELECT_OPTIONS_FQNAME = FqName("org.seasar.doma.jdbc.SelectOptions")
-private fun List<KtParameter>.filterSelectOptions(): List<KtParameter> {
-    return filter {
-        it.resolveDeclType()?.fqName == SELECT_OPTIONS_FQNAME
+
+private fun List<KtParameter>.filterSelectOptions(): List<KtParameter> =
+    filter { parameter ->
+        analyze(parameter) {
+            val symbol = parameter.symbol
+            val paramType = symbol.returnType
+
+            // 型に対応するクラスシンボルを取得
+            val classSymbol = paramType.expandedSymbol as? KaClassSymbol ?: return@analyze false
+
+            // FQ 名が org.seasar.doma.jdbc.SelectOptions かどうか判定
+            classSymbol.classId?.asSingleFqName() == SELECT_OPTIONS_FQNAME
+        }
     }
-}
+
 

--- a/src/main/java/siosio/doma/inspection/dao/UpdateMethodRule.kt
+++ b/src/main/java/siosio/doma/inspection/dao/UpdateMethodRule.kt
@@ -8,6 +8,8 @@ import org.jetbrains.kotlin.idea.references.*
 import org.jetbrains.kotlin.idea.util.*
 import org.jetbrains.kotlin.name.*
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import siosio.doma.*
 import siosio.doma.extension.*
 import siosio.doma.psi.*
@@ -118,7 +120,9 @@ val kotlinInsertMethodRule =
                     else ->
                         when (size) {
                             1 -> {
-                                val param = PsiTreeUtil.findChildOfType(first(), KtNameReferenceExpression::class.java)?.mainReference?.resolve()
+                                val param = PsiTreeUtil.findChildOfType(first(), KtNameReferenceExpression::class.java)
+                                    ?.mainReference
+                                    ?.resolve()
                                 when (param) {
                                     is PsiClass -> AnnotationUtil.isAnnotated(
                                         param,
@@ -126,7 +130,7 @@ val kotlinInsertMethodRule =
                                         AnnotationUtil.CHECK_TYPE
                                     )
                                     is KtClass -> {
-                                        param.findAnnotation(FqName(entityAnnotationName)) != null
+                                        param.hasEntityAnnotation(FqName(entityAnnotationName))
                                     }
                                     else -> false
                                 }
@@ -142,3 +146,11 @@ val kotlinDeleteMethodRule =
     kotlinRule {
         sql(false)
     }
+
+private fun KtClass.hasEntityAnnotation(fqName: FqName): Boolean = analyze(this) {
+    val symbol = this@hasEntityAnnotation.symbol as? KaClassSymbol ?: return@analyze false
+    symbol.annotations.any { anno ->
+        anno.classId?.asSingleFqName() == fqName
+    }
+}
+

--- a/src/main/java/siosio/doma/psi/PsiDaoFunction.kt
+++ b/src/main/java/siosio/doma/psi/PsiDaoFunction.kt
@@ -3,9 +3,11 @@ package siosio.doma.psi
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiAnnotation
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.asJava.toLightAnnotation
-import org.jetbrains.kotlin.idea.util.findAnnotation
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
@@ -17,49 +19,72 @@ import siosio.doma.sqlAnnotationName
 import siosio.doma.sqlExperimentalAnnotationName
 
 class PsiDaoFunction(
-        val psiFunction: KtNamedFunction,
-        val daoType: DaoType) : KtFunction by psiFunction {
+    val psiFunction: KtNamedFunction,
+    val daoType: DaoType
+) : KtFunction by psiFunction {
 
-    val daoAnnotation: PsiAnnotation = psiFunction.findAnnotation(FqName(daoType.annotationName))!!.toLightAnnotation()!!
+    /**
+     * DAO メソッドに付いている Doma アノテーション（@Select, @Update など）
+     */
+    val daoAnnotation: PsiAnnotation =
+        psiFunction.findAnnotationEntryByFqName(FqName(daoType.annotationName))
+            ?.toLightAnnotation()
+            ?: error("Annotation ${daoType.annotationName} not found on function ${psiFunction.name}")
 
     /**
      * このDaoメソッドが存在しているモジュール
      */
-    fun getModule(): Module? {
-        return project.findModule(this.containingFile.virtualFile)
-    }
+    fun getModule(): Module? =
+        project.findModule(this.containingFile.virtualFile)
 
     /**
      * このDaoメソッドがSQLファイルを必要とするかどうか
      */
-    fun useSqlFile(): Boolean = daoAnnotation.useSqlFile() ||
-            psiFunction.findAnnotation(FqName(sqlAnnotationName)) != null ||
-            psiFunction.findAnnotation(FqName(sqlExperimentalAnnotationName)) != null
+    fun useSqlFile(): Boolean =
+        daoAnnotation.useSqlFile() ||
+                psiFunction.hasAnnotationByFqName(FqName(sqlAnnotationName)) ||
+                psiFunction.hasAnnotationByFqName(FqName(sqlExperimentalAnnotationName))
 
-    fun getSqlFilePath(): String {
-        return "META-INF/${fqcnToFilePath()}/$name.${daoType.extension}"
-    }
+    fun getSqlFilePath(): String =
+        "META-INF/${fqcnToFilePath()}/$name.${daoType.extension}"
 
     /**
      * SQLファイルの存在有無
      *
      * @return 存在している場合`true`
      */
-    fun containsSqlFile(): Boolean {
-        return findSqlFile() != null
-    }
+    fun containsSqlFile(): Boolean =
+        findSqlFile() != null
 
     /**
      * SQLファイルを検索する。
      */
-    fun findSqlFile(): VirtualFile? {
-        return getModule()?.findSqlFileFromRuntimeScope(getSqlFilePath(), this.containingClass()!!)
-    }
+    fun findSqlFile(): VirtualFile? =
+        getModule()?.findSqlFileFromRuntimeScope(getSqlFilePath(), this.containingClass()!!)
 
     /**
      * このメソッドを持つクラスをパス形式の文字列で取得する
      */
-    private fun fqcnToFilePath(): String {
-        return containingClass()!!.fqName!!.asString().replace('.', '/')
-    }
+    private fun fqcnToFilePath(): String =
+        containingClass()!!.fqName!!.asString().replace('.', '/')
 }
+
+/**
+ * KtNamedFunction から、指定された FQ 名のアノテーションに対応する KtAnnotationEntry を取得する
+ * （K2 Analysis API ベース）
+ */
+private fun KtNamedFunction.findAnnotationEntryByFqName(fqName: FqName): KtAnnotationEntry? =
+    analyze(this) {
+        val symbol = this@findAnnotationEntryByFqName.symbol as? KaNamedFunctionSymbol ?: return@analyze null
+        val anno = symbol.annotations.firstOrNull { annotation ->
+            annotation.classId?.asSingleFqName() == fqName
+        } ?: return@analyze null
+        // KaAnnotation から元の PSI (KtAnnotationEntry) を取得
+        anno.psi as? KtAnnotationEntry
+    }
+
+/**
+ * KtNamedFunction に指定された FQ 名のアノテーションが付いているかどうか
+ */
+private fun KtNamedFunction.hasAnnotationByFqName(fqName: FqName): Boolean =
+    findAnnotationEntryByFqName(fqName) != null


### PR DESCRIPTION
- KtNamedFunction.findAnnotation(K1) を PSI ベースのアノテーション検索に置き換える
- KotlinCacheService / ResolutionUtils を呼び出していた箇所を削除（K2 モードで IllegalStateException: KotlinCacheService should not be used for the K2 mode を引き起こしていたため）
- Kotlin エンティティ検出処理を修正：
    - analyze {} を用いて symbol / expandedSymbol（KaClassSymbol）を扱う方式へ移行
    - 非推奨 API（getParameterSymbol(), expandedClassSymbol）を廃止
- DaoType.valueOf(KtNamedFunction) を PSI レベルだけでアノテーション判定する方式へ変更
- resolveDeclType() を含む、K1 依存のユーティリティをインスペクションルールから削除
- SelectOptions ルールの修正：構造検索 / ディスクリプタ解決を回避する実装へ
- PsiDaoFunction / PsiDaoMethod のクリーンアップ：K1 の解決経路を排除